### PR TITLE
Update keybindings.rst

### DIFF
--- a/docs/pages/keybindings.rst
+++ b/docs/pages/keybindings.rst
@@ -6,7 +6,7 @@ Key Bindings
 Editing Modes
 *************
 
-The key-bindings used when editing a cell or in the console are determined by the :option:`edit_mode` configuration variable. This can be set to ``micro``, ``emacs`` or ``vim`` to use key-bindings in the style of the respective text editor.
+The key-bindings used when editing a cell or in the console are determined by the :option:`edit_mode` configuration variable. This can be set to ``micro``, ``emacs`` or ``vi`` to use key-bindings in the style of the respective text editor.
 
 *******************
 Custom Key Bindings


### PR DESCRIPTION
Great project! There is an issue in the docs. For vim-like keybindings, the edit_mode needs to be set to "vi", not "vim". Took me 20 mins to figure out why my config was not working.