### PR TITLE
Keep blended ipympl frames in PNG format

### DIFF
--- a/changelog/+ipympl-diff-frame-format.fixed.rst
+++ b/changelog/+ipympl-diff-frame-format.fixed.rst
@@ -1,0 +1,1 @@
+Keep blended ``ipympl`` canvas frames in PNG format, so interactive figures redraw while being dragged

--- a/packages/euporie-core/src/euporie/core/comm/ipympl.py
+++ b/packages/euporie-core/src/euporie/core/comm/ipympl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from functools import partial
+from io import BytesIO
 from typing import TYPE_CHECKING
 
 from apptk.convert.datum import Datum
@@ -248,7 +249,12 @@ class MPLCanvasModel(IpyWidgetComm):
                 bg = display.datum.convert("pil")
                 fg = datum.convert("pil")
                 bg.paste(fg, (0, 0), fg)
-                datum = Datum(bg, format="pil")
+                # Keep the result as a PNG: the only converter registered from
+                # PIL images to sixel is the pure-python `timg` encoder, which
+                # is too slow to render a canvas being dragged
+                buffer = BytesIO()
+                bg.save(buffer, format="PNG")
+                datum = Datum(buffer.getvalue(), format="png")
             display.datum = datum
             self.data["state"]["_data_url"] = (
                 f"data:image/png;base64,{datum.convert('base64-png')}"


### PR DESCRIPTION
With `%matplotlib widget`, dragging a figure does not redraw it: the canvas freezes and the application stops responding for as long as the drag lasts.

`MPLCanvasModel.set_data` pastes a diff frame onto the canvas and stores the result as `Datum(bg, format="pil")`. The only converter registered from `pil` to `sixel` is `pil_to_sixel_py_timg`, a pure-python encoder — `png` has `img2sixel` and `chafa` available, but a PIL datum never reaches them.

Measured on a 3D figure dragged to rotate, in xfce-terminal (sixel) under tmux:

- before: 0 pixels of the canvas change during a full drag; the application handles 9 mouse events instead of 117 and runs no image conversion
- after: 88809 pixels change, and every intermediate frame is drawn

Re-encoding the blend as PNG is the whole fix.

Closes #170. Related to #146.

Developed with AI assistance; every measurement above is from a real terminal, not simulated.
