### PR TITLE
Take the cursor row from tmux when a pane is not active

### DIFF
--- a/changelog/+tmux-inactive-pane-mouse.fixed.rst
+++ b/changelog/+tmux-inactive-pane-mouse.fixed.rst
@@ -1,0 +1,1 @@
+Mouse events are no longer discarded while running in a tmux pane which is not the active one

--- a/packages/apptk/src/apptk/output/vt100.py
+++ b/packages/apptk/src/apptk/output/vt100.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess  # S404 - Security implications have been considered
 from base64 import b64encode
 from functools import lru_cache
 from typing import TYPE_CHECKING, TextIO
@@ -290,6 +291,37 @@ class Vt100_Output(PtkVt100_Output):
             _rows, _cols, px, py = _tiocgwinsz()
             self._pixel_size = (px, py)
         return self._pixel_size
+
+    def get_rows_below_cursor_position(self) -> int:
+        """Return the number of rows below the cursor.
+
+        tmux does not answer a cursor position report on behalf of a pane which
+        is not the active one, so an application running in an inactive pane
+        never learns its height, and mouse events are discarded until it does.
+        tmux does publish the cursor row of every pane, so ask it directly.
+        """
+        if not in_tmux() or not (pane := os.environ.get("TMUX_PANE")):
+            raise NotImplementedError
+        try:
+            reply = subprocess.run(  # S603 - the command is not user supplied
+                [
+                    "tmux",
+                    "display-message",
+                    "-p",
+                    "-t",
+                    pane,
+                    "#{pane_height} #{cursor_y}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=True,
+            ).stdout
+            height, cursor_y = (int(part) for part in reply.split())
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise NotImplementedError from error
+        # The cursor occupies a row of the pane, so one row is always below it
+        return max(1, height - cursor_y)
 
     def set_pixel_size(self, px: int, py: int) -> None:
         """Set terminal pixel dimensions."""


### PR DESCRIPTION
Closes #169.

`load_mouse_bindings` returns before any handler runs while `renderer.height_is_known` is `False`, and an application which is not full screen only learns its height from a cursor position report. tmux does not answer that request on behalf of an inactive pane, so a console in a neighbouring pane renders its widgets and then ignores the mouse.

`get_rows_below_cursor_position` is the hook prompt_toolkit already consults before falling back to a CPR round trip, and tmux publishes every pane cursor row whether or not the pane is active, so answering it from `#{cursor_y}` removes the dependency. Outside tmux it raises `NotImplementedError` as before, so nothing else changes.

Verified with the equivalent patch against euporie 2.10.4 in xfce-terminal under tmux: mouse dispatch went from 0/40 events delivered to 40/40, and an ipywidgets slider and an ipympl canvas both became draggable from an inactive pane. `rows_above_layout` resolves correctly because the console layout is anchored to the bottom of the pane.

The `subprocess` call only runs when the renderer has no height, which is once per reset rather than per event.

Developed with AI assistance.