### PR TITLE
Fall back when img2sixel writes no sixel data

### DIFF
--- a/changelog/+img2sixel-empty-output.fixed.rst
+++ b/changelog/+img2sixel-empty-output.fixed.rst
@@ -1,0 +1,1 @@
+Fall back to another converter when :command:`img2sixel` exits successfully without writing any sixel data

--- a/packages/apptk/src/apptk/convert/formats/sixel.py
+++ b/packages/apptk/src/apptk/convert/formats/sixel.py
@@ -55,7 +55,13 @@ async def png_to_sixel_img2sixel(
     if cols is not None:
         px, _ = get_app().output.cell_pixel_size
         cmd += [f"--width={int(cols * px)}"]
-    return (await call_subproc(datum.data, cmd)).decode()
+    output = (await call_subproc(datum.data, cmd)).decode()
+    if not output.startswith("\x1bP"):
+        # Some libsixel builds exit successfully having written nothing at all,
+        # which would reserve the image's cells and draw nothing in them
+        msg = "`img2sixel` produced no sixel data"
+        raise ValueError(msg)
+    return output
 
 
 register(

--- a/packages/apptk/src/apptk/convert/formats/sixel.py
+++ b/packages/apptk/src/apptk/convert/formats/sixel.py
@@ -56,11 +56,10 @@ async def png_to_sixel_img2sixel(
         px, _ = get_app().output.cell_pixel_size
         cmd += [f"--width={int(cols * px)}"]
     output = (await call_subproc(datum.data, cmd)).decode()
-    if not output.startswith("\x1bP"):
+    if not output or not output.startswith("\x1bP"):
         # Some libsixel builds exit successfully having written nothing at all,
         # which would reserve the image's cells and draw nothing in them
-        msg = "`img2sixel` produced no sixel data"
-        raise ValueError(msg)
+        raise ValueError("`img2sixel` produced no sixel data")
     return output
 
 


### PR DESCRIPTION
Closes #172.

`img2sixel` is tried before `chafa` for `png` to `sixel`, and its filter only checks that the command exists. libsixel 1.10.5-1.1, current in Arch, exits 0 writing nothing for every input, so the empty result is passed on as an image: the cells are reserved and left blank, and the fallback converters are never reached.

A converter which raises is already skipped in favour of the next one, so checking for the DCS introducer is enough to restore that behaviour. Verified on the affected libsixel build: figures render through `chafa` instead of appearing as empty boxes.

Developed with AI assistance.